### PR TITLE
Add configuration option for nix

### DIFF
--- a/src/kompos/cli/helmfile.py
+++ b/src/kompos/cli/helmfile.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 from kompos.komposconfig import HELMFILE_CONFIG_FILENAME, get_value_or
-from kompos.nix import nix_install, nix_out_path, writeable_nix_out_path
+from kompos.nix import nix_install, nix_out_path, writeable_nix_out_path, is_nix_enabled
 from kompos.cli.parser import SubParserConfig
 from kompos.hierarchical.composition_config_generator import (
     HierarchicalConfigGenerator,
@@ -85,7 +85,7 @@ class HelmfileRunner(HierarchicalConfigGenerator):
             helmfile_path = args.helmfile_path
 
         # Overwrite if nix is enabled.
-        if args.nix:
+        if is_nix_enabled(args, self.kompos_config.nix()):
             pname = self.kompos_config.helmfile_repo_name()
 
             raw_config = self.generate_config(

--- a/src/kompos/cli/parser.py
+++ b/src/kompos/cli/parser.py
@@ -41,6 +41,11 @@ class RootParser():
             help='Enable nix integration for remote resources'
         )
         parser.add_argument(
+            '--no-nix',
+            action='store_true',
+            help='Disable nix integration for remote resources'
+        )
+        parser.add_argument(
             '--version',
             action='version',
             version='%(prog)s v{version}'.format(version=__version__)

--- a/src/kompos/cli/terraform.py
+++ b/src/kompos/cli/terraform.py
@@ -16,7 +16,7 @@ import json
 from subprocess import Popen, PIPE
 
 from himl.main import ConfigRunner
-from kompos.nix import nix_install, nix_out_path, writeable_nix_out_path
+from kompos.nix import nix_install, nix_out_path, writeable_nix_out_path, is_nix_enabled
 from kompos.komposconfig import (
     TERRAFORM_CONFIG_FILENAME,
     TERRAFORM_PROVIDER_FILENAME,
@@ -242,7 +242,7 @@ class TerraformRunner():
             )
 
             # Overwrite with the nix output, if the nix integration is enabled.
-            if args.nix:
+            if is_nix_enabled(args, self.kompos_config.nix()):
                 pname = self.kompos_config.terraform_repo_name()
 
                 nix_install(

--- a/src/kompos/data/config_schema.json
+++ b/src/kompos/data/config_schema.json
@@ -114,6 +114,11 @@
     "min_version": {
       "type": "string",
       "description": "The minimum kompos version allowed"
+    },
+    "nix": {
+      "type": "boolean",
+      "description": "Whether to enable versioning with nix",
+      "default": false
     }
   },
   "required": [

--- a/src/kompos/komposconfig.py
+++ b/src/kompos/komposconfig.py
@@ -135,6 +135,9 @@ class KomposConfig():
     def all(self):
         return self.config
 
+    def nix(self):
+        return get_value_or(self.config, "nix")
+
     def vault_backend(self):
         if get_value_or(self.config, "vault/enabled"):
             os.environ["VAULT_ADDR"] = get_value_or(self.config, "vault/url")

--- a/src/kompos/nix.py
+++ b/src/kompos/nix.py
@@ -145,3 +145,16 @@ def writeable_nix_out_path(name):
     copy_tree(out_path, tmp_dir)
 
     return tmp_dir
+
+
+def is_nix_enabled(cli_opts, cfg_opt):
+    """
+    Decide if nix should be enabled. CLI takes precedence over configuration file.
+    """
+    if cli_opts.nix:
+        return True
+
+    if cli_opts.no_nix:
+        return False
+
+    return cfg_opt


### PR DESCRIPTION
Enables toggling through the configuration file. CLI still takes precedence.